### PR TITLE
Add dropdown menu after user login

### DIFF
--- a/content/homepage/index.html
+++ b/content/homepage/index.html
@@ -5,9 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>User Home</title>
     <script type="module" src="/homepage.js"></script>
+    <style>
+        .user-menu { margin-top: 1rem; position: relative; display: inline-block; }
+        .user-menu button { cursor: pointer; }
+        .user-menu .menu-list { position: absolute; background: #fff; border: 1px solid #ccc; }
+        .user-menu .menu-list li { padding: 4px 8px; }
+        .user-menu .menu-list li a { text-decoration: none; color: inherit; display: block; }
+    </style>
 </head>
 <body>
     <h2 id="welcome">Loading...</h2>
-    <button id="logout">Logout</button>
+    <div class="user-menu">
+        <button id="menuToggle">Menu ▼</button>
+        <ul id="menuList" class="menu-list" style="display:none; list-style:none; padding:0; margin-top:4px;">
+            <li><a href="/dashboard/">Dashboard</a></li>
+            <li><a href="#" id="logout">Logout</a></li>
+        </ul>
+    </div>
 </body>
 </html>

--- a/static/homepage.js
+++ b/static/homepage.js
@@ -18,6 +18,8 @@ const db = getFirestore();
 
 const welcomeEl = document.getElementById('welcome');
 const logoutBtn = document.getElementById('logout');
+const menuToggle = document.getElementById('menuToggle');
+const menuList = document.getElementById('menuList');
 
 async function loadUser() {
   const uid = localStorage.getItem('loggedInUserId');
@@ -31,6 +33,9 @@ async function loadUser() {
     if (snap.exists()) {
       const data = snap.data();
       welcomeEl.textContent = `Welcome, ${data.firstName}!`;
+      if (menuToggle) {
+        menuToggle.textContent = `${data.firstName} \u25BC`;
+      }
     } else {
       welcomeEl.textContent = 'Welcome!';
     }
@@ -40,7 +45,15 @@ async function loadUser() {
   }
 }
 
-logoutBtn.addEventListener('click', () => {
+
+if (menuToggle && menuList) {
+  menuToggle.addEventListener('click', () => {
+    menuList.style.display = menuList.style.display === 'block' ? 'none' : 'block';
+  });
+}
+
+logoutBtn.addEventListener('click', (e) => {
+  e.preventDefault();
   signOut(auth).finally(() => {
     localStorage.removeItem('loggedInUserId');
     window.location.href = '/login/';


### PR DESCRIPTION
## Summary
- show dropdown after login with Dashboard and Logout links
- fetch user name for menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a721d49088332b0094166c17748da